### PR TITLE
Update com_content.php

### DIFF
--- a/packages/mod_junewsultra/helper/com_content.php
+++ b/packages/mod_junewsultra/helper/com_content.php
@@ -650,6 +650,9 @@ class com_content extends Helper
 
 					if(is_object($images))
 					{
+						$images->image_intro=substr($images->image_intro, 0, strpos($images->image_intro, '#'));
+						$images->image_fulltext=substr($images->image_fulltext, 0, strpos($images->image_fulltext, '#'));
+						
 						$_image_intro    = file_exists($images->image_intro);
 						$_image_fulltext = file_exists($images->image_fulltext);
 


### PR DESCRIPTION
joomla 4.0.4 adds something like "#joomlaImage://local-images/sampledata/cassiopeia/nasa1-400.jpg?width=400&height=400" after the name of the image when you select intro or fulltext image into an article.
This causes the test file_exists($images->image_intro) and file_exists($images->image_fulltext) to return always false.